### PR TITLE
handling index directory names with timestamp at the end

### DIFF
--- a/upgradeindex/upgradeindex.sh
+++ b/upgradeindex/upgradeindex.sh
@@ -125,11 +125,13 @@ if [[ "X$CORES" == "X" ]] ; then
   echo "No indices found on path $DIR"
 else
     for c in $CORES ; do
-      if [[ -d $c/data/index ]]; then
+      if find $c/data -maxdepth 1 -type d -name 'index*' 1> /dev/null 2>&1; then
         name=$(echo $c | sed -e 's/.*\///g')
         abspath=$(cd "$(dirname "$c")"; pwd)/$(basename "$c")
         echo "Core $name - $abspath"
-        upgrade $c/data/index
+        find $c/data -maxdepth 1 -type d -name 'index*' | while read indexDir; do
+	      upgrade "$indexDir"
+        done
       else
         echo "No index folder found for $name"
       fi


### PR DESCRIPTION
The index directory may be created with a timestamp at the end (i.e. index.20160717152012750) in this case those index directories will not be handled by current solution. 

See http://grokbase.com/t/lucene/solr-user/1396zkcgx0/data-index-naming-format
